### PR TITLE
Default initial default camera to YUYV pixel format

### DIFF
--- a/stage2/01-sys-tweaks/files/frc.json
+++ b/stage2/01-sys-tweaks/files/frc.json
@@ -4,7 +4,7 @@
 	{
 	    "name": "rPi Camera 0",
 	    "path": "/dev/video0",
-	    "pixel format": "mjpeg",
+	    "pixel format": "yuyv",
 	    "width": 160,
 	    "height": 120,
 	    "fps": 30


### PR DESCRIPTION
MJPEG default compression is usually too high for efficient streams, and
some cameras don't support MJPEG modes.