### PR TITLE
Fix ordering between CameraServer.getInstance and UsbCamera creation

### DIFF
--- a/deps/examples/cpp-multiCameraServer/main.cpp
+++ b/deps/examples/cpp-multiCameraServer/main.cpp
@@ -170,8 +170,8 @@ bool ReadConfig() {
 cs::UsbCamera StartCamera(const CameraConfig& config) {
   wpi::outs() << "Starting camera '" << config.name << "' on " << config.path
               << '\n';
-  cs::UsbCamera camera{config.name, config.path};
   auto inst = frc::CameraServer::GetInstance();
+  cs::UsbCamera camera{config.name, config.path};
   auto server = inst->StartAutomaticCapture(camera);
 
   camera.SetConfigJson(config.config);

--- a/deps/examples/java-multiCameraServer/src/main/java/Main.java
+++ b/deps/examples/java-multiCameraServer/src/main/java/Main.java
@@ -181,8 +181,8 @@ public final class Main {
    */
   public static VideoSource startCamera(CameraConfig config) {
     System.out.println("Starting camera '" + config.name + "' on " + config.path);
-    UsbCamera camera = new UsbCamera(config.name, config.path);
     CameraServer inst = CameraServer.getInstance();
+    UsbCamera camera = new UsbCamera(config.name, config.path);
     MjpegServer server = inst.startAutomaticCapture(camera);
 
     Gson gson = new GsonBuilder().create();

--- a/deps/examples/python-multiCameraServer/multiCameraServer.py
+++ b/deps/examples/python-multiCameraServer/multiCameraServer.py
@@ -134,8 +134,8 @@ def readConfig():
 """Start running the camera."""
 def startCamera(config):
     print("Starting camera '{}' on {}".format(config.name, config.path))
-    camera = UsbCamera(config.name, config.path)
     inst = CameraServer.getInstance()
+    camera = UsbCamera(config.name, config.path)
     server = inst.startAutomaticCapture(camera=camera, return_server=True)
 
     camera.setConfigJson(json.dumps(config.config))

--- a/deps/tools/multiCameraServer.cpp
+++ b/deps/tools/multiCameraServer.cpp
@@ -171,8 +171,8 @@ bool ReadConfig() {
 void StartCamera(const CameraConfig& config) {
   wpi::outs() << "Starting camera '" << config.name << "' on " << config.path
               << '\n';
-  cs::UsbCamera camera{config.name, config.path};
   auto inst = frc::CameraServer::GetInstance();
+  cs::UsbCamera camera{config.name, config.path};
   auto server = inst->StartAutomaticCapture(camera);
 
   camera.SetConfigJson(config.config);


### PR DESCRIPTION
If the CameraServer instance is started after the UsbCamer is created, it
never gets the source created event to actually build the NetworkTable table.