### PR TITLE
Romi: On first boot, set a unique SSID

### DIFF
--- a/stage5/01-sys-tweaks/00-packages
+++ b/stage5/01-sys-tweaks/00-packages
@@ -1,5 +1,6 @@
 avrdude
 hostapd
 dnsmasq
+espeak
 python-serial
 python3-serial

--- a/stage5/01-sys-tweaks/01-run.sh
+++ b/stage5/01-sys-tweaks/01-run.sh
@@ -9,6 +9,10 @@ install -m 755 files/resize2fs_once	"${ROOTFS_DIR}/etc/init.d/"
 install -m 755 files/romi-sayid.sh	"${ROOTFS_DIR}/usr/local/frc/bin/"
 install -m 755 files/romi_sayid		"${ROOTFS_DIR}/etc/init.d/"
 
+on_chroot << EOF
+systemctl enable romi_sayid
+EOF
+
 # enable i2c
 install -m 644 files/i2c.conf "${ROOTFS_DIR}/etc/modules-load.d/"
 sed -i -e "s/^#dtparam=i2c_arm=on/dtparam=i2c_arm=on/" "${ROOTFS_DIR}/boot/config.txt"

--- a/stage5/01-sys-tweaks/01-run.sh
+++ b/stage5/01-sys-tweaks/01-run.sh
@@ -2,6 +2,13 @@
 
 SUB_STAGE_DIR=${PWD}
 
+# Override resize2fs_once to add unique SSID setting on first boot
+install -m 755 files/resize2fs_once	"${ROOTFS_DIR}/etc/init.d/"
+
+# Install romi_sayid.sh and startup script
+install -m 755 files/romi-sayid.sh	"${ROOTFS_DIR}/usr/local/frc/bin/"
+install -m 755 files/romi_sayid		"${ROOTFS_DIR}/etc/init.d/"
+
 # enable i2c
 install -m 644 files/i2c.conf "${ROOTFS_DIR}/etc/modules-load.d/"
 sed -i -e "s/^#dtparam=i2c_arm=on/dtparam=i2c_arm=on/" "${ROOTFS_DIR}/boot/config.txt"

--- a/stage5/01-sys-tweaks/files/resize2fs_once
+++ b/stage5/01-sys-tweaks/files/resize2fs_once
@@ -1,0 +1,34 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          resize2fs_once
+# Required-Start:
+# Required-Stop:
+# Default-Start: 3
+# Default-Stop:
+# Short-Description: Resize the root filesystem to fill partition
+# Description:
+### END INIT INFO
+. /lib/lsb/init-functions
+case "$1" in
+  start)
+    log_daemon_msg "Starting resize2fs_once"
+    ID=`grep ^Serial /proc/cpuinfo | cut -d ':' -f 2 | cut -c 10-`
+    if [ -n "$ID" ]; then
+      echo "WPILibPi-$ID" > /boot/default-ssid.txt
+      sed -e "s/^ssid=WPILibPi$/ssid=WPILibPi-$ID/" /etc/hostapd/hostapd.conf.orig > /etc/hostapd/hostapd.conf
+      ID_SPACES=`echo $ID | sed -e 's/\(.\)/\1 /g'`
+      /usr/bin/espeak -s 140 -g 5 "WPILib Pi dash $ID_SPACES" --stdout > /boot/default-ssid.wav
+    fi
+    ROOT_DEV=$(findmnt / -o source -n) &&
+    resize2fs $ROOT_DEV &&
+    update-rc.d resize2fs_once remove &&
+    rm /etc/init.d/resize2fs_once &&
+    sed -i '/vfat\|ext4/s/defaults/defaults,ro/' /etc/fstab &&
+    log_end_msg $? &&
+    reboot
+    ;;
+  *)
+    echo "Usage: $0 start" >&2
+    exit 3
+    ;;
+esac

--- a/stage5/01-sys-tweaks/files/romi-sayid.sh
+++ b/stage5/01-sys-tweaks/files/romi-sayid.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+[ -f /boot/default-ssid.txt ] || exit 0
+[ -f /boot/default-ssid.wav ] || exit 0
+[ -f /etc/hostapd/hostapd.conf ] || exit 0
+
+SSID=`grep ^ssid= /etc/hostapd/hostapd.conf | cut -c 6-`
+DEFAULTID=`cat /boot/default-ssid.txt 2>/dev/null`
+
+[ "$SSID" = "$DEFAULTID" ] || exit 0
+
+echo $$ > /run/romi_sayid.pid
+
+MESSAGE="Jr ner Ebzv.  Lbh jvyy or nffvzvyngrq."
+
+while true
+do
+    for i in {1..10}
+    do
+        aplay -q /boot/default-ssid.wav
+    done
+    echo $MESSAGE | tr 'A-Za-z' 'N-ZA-Mn-za-m' | espeak -s 140 -g 5 --stdin --stdout | aplay -q
+done

--- a/stage5/01-sys-tweaks/files/romi_sayid
+++ b/stage5/01-sys-tweaks/files/romi_sayid
@@ -1,0 +1,46 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          romi_sayid
+# Required-Start:
+# Required-Stop:
+# Default-Start: 3
+# Default-Stop:
+# Short-Description: romi sayid
+# Description: Speaks the Romi unique ID to the audio output
+### END INIT INFO
+
+DAEMON=/usr/local/frc/bin/romi-sayid.sh
+PIDFILE=/run/romi_sayid.pid
+
+. /lib/lsb/init-functions
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting romi sayid" "romi_sayid"
+    /sbin/start-stop-daemon --start --nicelevel 0 --quiet --oknodo --chdir "$PWD" --background --pidfile $PIDFILE --exec $DAEMON
+    log_end_msg $?
+    ;;
+  stop)
+    log_daemon_msg "Stopping romi sayid" "romi_sayid"
+    killproc -p $PIDFILE $DAEMON TERM
+    log_end_msg $?
+    ;;
+  status)
+    if pidofproc -p $PIDFILE $DAEMON >/dev/null 2>&1; then
+      echo "$DAEMON is running";
+      exit 0;
+    else
+      echo "$DAEMON is NOT running";
+      if test -f $PIDFILE; then exit 2; fi
+      exit 3;
+    fi
+    ;;
+  force-reload|restart)
+    $0 stop
+    $0 start
+    ;;
+  *)
+    echo "Usage: /etc/init.d/romi_sayid {start|stop|restart|force-reload}"
+    exit 1
+    ;;
+esac

--- a/stage5/02-net-tweaks/01-run.sh
+++ b/stage5/02-net-tweaks/01-run.sh
@@ -8,7 +8,8 @@ mkdir -p "${ROOTFS_DIR}/var/lib/systemd/rfkill/"
 echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
 echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
 
-install -m 644 files/hostapd.conf "${ROOTFS_DIR}/etc/hostapd/hostapd.conf"
+# Install hostapd.conf to .orig so it's not activated on first boot
+install -m 644 files/hostapd.conf "${ROOTFS_DIR}/etc/hostapd/hostapd.conf.orig"
 install -m 644 files/dnsmasq.conf "${ROOTFS_DIR}/etc/dnsmasq.d/wpilib.conf"
 
 cat <<END >> "${ROOTFS_DIR}/etc/wpa_supplicant/wpa_supplicant.conf"


### PR DESCRIPTION
This helps avoid SSID conflicts when configuring multiple devices.

The SSID can be discovered in two ways:
- It's written as a text file to the SD card /boot partition.  This is a FAT
  partition that can be read on Windows systems.
- It's spoken (via text to speech) to the Pi audio jack.