### PR TITLE
Update RobotPy bits to 2021

### DIFF
--- a/stage3/01-sys-tweaks/01-run.sh
+++ b/stage3/01-sys-tweaks/01-run.sh
@@ -54,15 +54,15 @@ wget -nc -nv -O allwpilib.tar.gz \
 
 # pynetworktables
 wget -nc -nv -O pynetworktables.tar.gz \
-    https://github.com/robotpy/pynetworktables/archive/2020.0.1.tar.gz
+    https://github.com/robotpy/pynetworktables/archive/2021.0.0.tar.gz
 
 # robotpy-cscore
 wget -nc -nv -O robotpy-cscore.tar.gz \
-    https://github.com/robotpy/robotpy-cscore/archive/2020.0.1.tar.gz
+    https://github.com/robotpy/robotpy-cscore/archive/2021.0.0.tar.gz
 
 # pybind11 submodule of robotpy-cscore
 wget -nc -nv -O pybind11.tar.gz \
-    https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz
+    https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz
 
 # pixy2
 wget -nc -nv -O pixy2.tar.gz \
@@ -94,12 +94,12 @@ mv allwpilib-* allwpilib
 # pynetworktables
 tar xzf "${DOWNLOAD_DIR}/pynetworktables.tar.gz"
 mv pynetworktables-* pynetworktables
-echo "__version__ = '2020.0.1'" > pynetworktables/_pynetworktables/_impl/version.py
+echo "__version__ = '2021.0.0'" > pynetworktables/_pynetworktables/_impl/version.py
 
 # robotpy-cscore
 tar xzf "${DOWNLOAD_DIR}/robotpy-cscore.tar.gz"
 mv robotpy-cscore-* robotpy-cscore
-echo "__version__ = '2020.0.1'" > robotpy-cscore/cscore/version.py
+echo "__version__ = '2021.0.0'" > robotpy-cscore/cscore/version.py
 pushd robotpy-cscore
 rm -rf pybind11
 tar xzf "${DOWNLOAD_DIR}/pybind11.tar.gz"


### PR DESCRIPTION
For FRCVision/WPILibPi users, there is a bug/regression in the behaviour of `CameraServer.startAutomaticCapture()`, specifically with the default behaviour of `return_server`. This was fixed in robotpy-cscore 2021.0.0.

My apologies to any teams who have been bitten by this bug.
