### PR TITLE
Romi gyro calibration time left to whole number instead of large decimals

### DIFF
--- a/deps/tools/configServer/src/resources/frcvision.js
+++ b/deps/tools/configServer/src/resources/frcvision.js
@@ -1288,7 +1288,7 @@ $('#romiCalibrateButton').click(function() {
           $('#romiCalibrateButton').button('reset');
         }
 
-        $('#romiCalibrationTimeLeft').html(calibrationState.estimatedTimeLeft + " seconds left");
+        $('#romiCalibrationTimeLeft').html(Math.ceil(calibrationState.estimatedTimeLeft) + " seconds left");
         $('#romiCalibrationProgressPercent').html("(" + calibrationState.percentComplete + "%)");
         $('#romiCalibrationProgressBar').attr("style", "width: " + calibrationState.percentComplete + "%");
         $('#romiCalibrationProgressBar').attr("aria-valuenow", calibrationState.percentComplete.toString());


### PR DESCRIPTION
Instead of showing very large numbers in the estimated seconds left for gyro calibration it will only show the number of seconds left in a whole number using `Math.ceil`. 